### PR TITLE
Remove extraneous whitespace

### DIFF
--- a/find-by-extension
+++ b/find-by-extension
@@ -98,11 +98,11 @@ done
 
 max=$#
 index=2
-extensions="--regexp= '$1\$'"
+extensions="--regexp='$1\$'"
 shift 1
 
 while [ ${index} -le ${max} ]; do
-    extensions="${extensions} --regexp= '$1\$'"
+    extensions="${extensions} --regexp='$1\$'"
     index=$((index + 1))
     shift 1
 done


### PR DESCRIPTION
This PR fixes the below bug which occurs when the Git post-checkout hook calls `find-by-extension`.

```shell
Ensuring Prettier configuration files are present...
grep: .py$: No such file or directory
```

The bug was caused by a malformed `grep` command. Instead of appending `--regexp='<extension>$'` for each extension to find by, `--regexp= '<extension>$'` was appended for each. The extraneous whitespace caused the values passed to each `--regexp` flag to be empty and for each extension to be passed as positional arguments and interpreted as filenames.

In the case of the call from the Git post-checkout hook, `grep` was told to search both standard input and the file named `.py$`, which did not exist.