### PR TITLE
Feature: Improve PR Titles

### DIFF
--- a/create-pr
+++ b/create-pr
@@ -118,8 +118,11 @@ if [[ -z "${base}" ]]; then
 fi
 
 
+title=$(git branch --show-current)
+title=$(echo ${title} | sed -e 's|\(.*\)/|\u\1:-|')  # Replace '<type>/' prefix with '<Type>:-'
+title=$(echo ${title} | sed -e 's|-\(.\)| \u\1|g')   # convert kebab-case to Title Case
 assert_success "Creating pull request..." \
-               "gh pr create --assignee @me --base '${base}' --fill ${labels}" \
+               "gh pr create --assignee @me --base '${base}' --fill ${labels} --title '${title}'" \
                "Error creating pull request" \
                ${GITHUB_ERROR} \
                "Pull request created\n"


### PR DESCRIPTION
The original title of this PR was generated with the `create-pr` included in this PR and hence serves as a test for the changes.

~It is clear that it cannot handle initialisms; however, there is no way to generically handle those in such a tool.~

If initialisms are capitalised in the branch name, their capitalisation is maintained.